### PR TITLE
EZ-894-referenced card component white spacing in middle if only two …

### DIFF
--- a/pattern-lab/source/_patterns/01-molecules/06-ReferenceCards/00-reference-cards.scss
+++ b/pattern-lab/source/_patterns/01-molecules/06-ReferenceCards/00-reference-cards.scss
@@ -9,7 +9,8 @@
     @include respond(tab) {
       display: flex;
       flex-wrap: wrap;
-      justify-content: space-between;
+      align-items: stretch;
+      justify-content: start;
     }
 
     > .field__item {
@@ -26,10 +27,10 @@
       &:nth-of-type(3n+2) {
 
         @include respond(tab) {
-          margin: 0 18px;
+          margin: 0 18px 30px 18px;
         }
         @include respond(desktop) {
-          margin: 0 20px;
+          margin: 0 20px 30px 20px;
         }
       }
     }


### PR DESCRIPTION
Issue is when we have only two items in the card in the row , first item show on left and second item show in the right ans middle portion are blank and white..
In the PR its fixed now if when we have two items in a row it will be show one by one no spacing or white space will be show there, 